### PR TITLE
Fix RecyclerViewにFloatingButtonが重ならないように修正

### DIFF
--- a/src/app/src/main/res/layout/fragment_miche_timer.xml
+++ b/src/app/src/main/res/layout/fragment_miche_timer.xml
@@ -13,6 +13,8 @@
             android:scrollbars="vertical"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:paddingBottom="75dp"
+            android:clipToPadding="false"
             android:orientation="vertical"/>
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton


### PR DESCRIPTION
* clip to paddingをオフにしてfloating buttonとRecyclerViewの要素がかぶらないようにした。